### PR TITLE
use postcss selector parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,6 @@
     "csswg"
   ],
   "dependencies": {
-    "postcss-selector-parser": "^6.0.6"
+    "postcss-selector-parser": "6.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -117,5 +117,8 @@
     "specs",
     "w3c",
     "csswg"
-  ]
+  ],
+  "dependencies": {
+    "postcss-selector-parser": "^6.0.6"
+  }
 }

--- a/src/lib/merge-selectors.js
+++ b/src/lib/merge-selectors.js
@@ -1,27 +1,89 @@
-import { replaceable } from './valid-selector.js'
+import parser from 'postcss-selector-parser'
 
 export default function mergeSelectors(fromSelectors, toSelectors) {
+	let complexFromSelector = false
+	let fromSelectorIsList = fromSelectors.length > 1
+	const fromSelectorAST = parser().astSync(fromSelectors.join(','))
+	const fromSelectorWithIsAST = parser().astSync(`:is(${fromSelectors.join(',')})`)
+
+	let fromSelectorCounterAST = 0
+	fromSelectorAST.walk((x) => {
+		if (x.type === 'root') {
+			return
+		}
+
+		fromSelectorCounterAST++
+	})
+
+	if (fromSelectorCounterAST > 2) {
+		complexFromSelector = true
+	}
+
 	return toSelectors.map((toSelector) => {
-		let needsIsOnFromSelector = false
+		return parser((selectors) => {
+			selectors.walkNesting((selector) => {
+				if (fromSelectorIsList) {
+					selector.replaceWith(fromSelectorWithIsAST.clone())
+					return
+				}
 
-		if (fromSelectors.length > 1) {
-			needsIsOnFromSelector = true
-		}
+				// foo &foo foo & baz -> foo &:is(foo) foo & baz
+				if (
+					selector.next() &&
+					selector.next().type === 'tag'
+				) {
+					const isPseudo = parser.pseudo({ value: ':is' })
+					isPseudo.append(selector.next().clone())
+					selector.next().replaceWith(isPseudo)
 
-		// foo &foo foo & baz -> foo &:is(foo) foo & baz
-		toSelector = toSelector.replace(/&((?:[\w-_|])(?:[^\s,{]*))/g, (match, p1) => {
-			return `&:is(${p1})`
-		})
+					if (complexFromSelector) {
+						selector.replaceWith(fromSelectorWithIsAST.clone())
+						return
+					}
 
-		// foo& -> foo:is(&)
-		if (fromSelectors.length === 1 && /^(?:[\w-_|])/.test(fromSelectors[0])) {
-			toSelector = toSelector.replace(/([\w-_|]+)(?:&)/g, (match, p1) => {
-				return `${p1}:is(&)`
+					selector.replaceWith(fromSelectorAST.clone())
+					return
+				}
+
+				// h1 and foo can combine to fooh1|h1foo which would be a different selector.
+				// h1 and .foo can combine to .fooh1 which would be a different selector.
+				// h1 { .foo& {} } -> h1.foo: {}
+				// h1 { foo& {} } -> foo:is(h1) {}
+				if (
+					selector.prev() &&
+					selector.prev().type !== 'combinator' &&
+					fromSelectorAST.first &&
+					fromSelectorAST.first.first &&
+					fromSelectorAST.first.first.type === 'tag'
+				) {
+					if (complexFromSelector) {
+						selector.replaceWith(fromSelectorWithIsAST.clone())
+						return
+					}
+
+					let firstPrecedingNonCombinatorNode = selector.prev()
+					while (firstPrecedingNonCombinatorNode.prev() && firstPrecedingNonCombinatorNode.prev().type !== 'combinator') {
+						firstPrecedingNonCombinatorNode = firstPrecedingNonCombinatorNode.prev()
+					}
+
+					if (firstPrecedingNonCombinatorNode.type !== 'tag') {
+						// Safe to just prepend the parent selector.
+						// h1 { .foo& {} } -> h1.foo: {}
+						selector.parent.insertBefore(firstPrecedingNonCombinatorNode, fromSelectorAST.clone())
+						selector.remove()
+						return
+					}
+
+					// Unsafe -> wrapping the parent selector in :is().
+					// h1 { foo& {} } -> foo:is(h1) {}
+					const isPseudo = parser.pseudo({ value: ':is' })
+					isPseudo.append(fromSelectorAST.clone())
+					selector.replaceWith(isPseudo)
+					return
+				}
+
+				selector.replaceWith(fromSelectorAST.clone())
 			})
-		}
-
-		return needsIsOnFromSelector
-				? toSelector.replace(replaceable, `:is(${fromSelectors.join(', ')})`)
-				: toSelector.replace(replaceable, fromSelectors.join(', '))
+		}).processSync(toSelector)
 	})
 }

--- a/src/lib/valid-selector.js
+++ b/src/lib/valid-selector.js
@@ -1,2 +1,0 @@
-export const replaceable = /&/g
-

--- a/test/at-rule.expect.css
+++ b/test/at-rule.expect.css
@@ -46,15 +46,15 @@ a e {
 		color: red
 }
 
-.foo:is(h1) {
+h1.foo {
 		color: blue
 }
 
-.foo:is(h1) .baz h1 {
+h1.foo .baz h1 {
 		color: blue
 }
 
-.foo:is(h1), .bar:is(h1) {
+h1.foo, h1.bar {
 		color: blue
 }
 

--- a/test/basic.css
+++ b/test/basic.css
@@ -45,6 +45,34 @@ a {
 			order: 16;
 		}
 	}
+
+	@nest body& {
+		order: 17;
+	}
+
+	@nest html body& {
+		order: 18;
+	}
+}
+
+a {
+	@nest .foo& {
+		order: 19;
+	}
+
+	@nest .foo .bar& {
+		order: 20;
+	}
+}
+
+a b {
+	@nest .foo& {
+		order: 21;
+	}
+
+	@nest .foo .bar& {
+		order: 22;
+	}
 }
 
 .foo {
@@ -57,5 +85,17 @@ a {
 li {
 	&+& {
 		background: red;
+	}
+}
+
+.foo {
+	&:where(h1) {
+		background: red;
+	}
+}
+
+a {
+	& b[a="a&b"] {
+		order: 7;
 	}
 }

--- a/test/basic.expect.css
+++ b/test/basic.expect.css
@@ -64,6 +64,30 @@ a {
 }
 		}
 
+body:is(a) {
+		order: 17
+}
+
+html body:is(a) {
+		order: 18
+}
+
+a.foo {
+		order: 19
+}
+
+.foo a.bar {
+		order: 20
+}
+
+.foo:is(a b) {
+		order: 21
+}
+
+.foo .bar:is(a b) {
+		order: 22
+}
+
 .foo:is(h1),
 	.foo:is(h2) {
 		color: red;
@@ -71,4 +95,12 @@ a {
 
 li+li {
 		background: red;
+	}
+
+.foo:where(h1) {
+		background: red;
+	}
+
+a b[a="a&b"] {
+		order: 7;
 	}

--- a/test/complex.expect.css
+++ b/test/complex.expect.css
@@ -1,6 +1,6 @@
 body > p, body > ul {
 	margin: 0
 }
-:is(body > p, body > ul) ~ :is(body > p, body > ul) {
+:is(body > p,body > ul) ~ :is(body > p,body > ul) {
 		margin-top: 0;
 	}

--- a/test/direct.expect.css
+++ b/test/direct.expect.css
@@ -1,24 +1,24 @@
 a, b {
 	order: 1;
 }
-:is(a, b) c, :is(a, b) d {
+:is(a,b) c, :is(a,b) d {
 		order: 2;
 	}
-:is(:is(a, b) c, :is(a, b) d) e, :is(:is(a, b) c, :is(a, b) d) f {
+:is(:is(a,b) c,:is(a,b) d) e, :is(:is(a,b) c,:is(a,b) d) f {
 			order: 3;
 		}
-:is(a, b) c, :is(a, b) d {
+:is(a,b) c, :is(a,b) d {
 		order: 4;
 	}
 a, b {
 	order: 1;
 }
-:is(a, b) c, :is(a, b) d {
+:is(a,b) c, :is(a,b) d {
 		order: 2;
 }
-:is(:is(a, b) c, :is(a, b) d) e, :is(:is(a, b) c, :is(a, b) d) f {
+:is(:is(a,b) c,:is(a,b) d) e,:is(:is(a,b) c,:is(a,b) d) f {
 			order: 3;
 }
-:is(a, b) c, :is(a, b) d {
+:is(a,b) c, :is(a,b) d {
 		order: 4;
 }

--- a/test/spec-examples.expect.css
+++ b/test/spec-examples.expect.css
@@ -56,8 +56,8 @@ table.colortable th {
 .bar {
 	color: blue
 }
-:is(.foo, .bar)+.baz,
-	:is(.foo, .bar).qux {
+:is(.foo,.bar)+.baz,
+	:is(.foo,.bar).qux {
 		color: red;
 	}
 
@@ -114,7 +114,7 @@ table.colortable th {
 */
 
 /* The parent selector can be arbitrarily complicated */
-:is(.error, #404):hover>.baz {
+:is(.error,#404):hover>.baz {
 		color: red;
 	}
 
@@ -123,7 +123,7 @@ table.colortable th {
 */
 
 /* As can the nested selector */
-.foo:is(.bar, .foo.baz) {
+.foo:is(.bar,.foo.baz) {
 		color: red;
 	}
 


### PR DESCRIPTION
regexp approach currently in main fails this case :

```css
a {
	& b[a="a&b"] {
		order: 7;
	}
}
```

-----

side effect from this change is that we can reorder selectors and avoid `:is()` in some cases:

```diff
- .foo:is(h1), .bar:is(h1) {
+ h1.foo, h1.bar {
```